### PR TITLE
UnitBuff don't work for player when mind controlled

### DIFF
--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -40,8 +40,14 @@ local function BuffFrameUpdate(frame, buildOnly)
 	local isPlayer = auraframe:GetParent().unitGroup == "player"
 	local config = LunaUF.db.profile.units[auraframe:GetParent().unitGroup].auras
 	local numBuffs = 0
-	while UnitBuff(unit, numBuffs+1) do
-		numBuffs = numBuffs + 1
+	if isPlayer then
+		while GetPlayerBuff(numBuffs, "HELPFUL") ~= -1 do
+			numBuffs = numBuffs + 1
+		end
+	else
+		while UnitBuff(unit, numBuffs+1) do
+			numBuffs = numBuffs + 1
+		end
 	end
 	local rows = math.ceil(numBuffs/config.AurasPerRow)
 	local height = rows*auraframe.buffbuttons[1]:GetHeight()+rows


### PR DESCRIPTION
When the "player" unit is mind controlled UnitBuff("player", i) returns always null. As a consequence auraframe's height is set to 1 in BuffFrameUpdate and buff/debuff frames overlap. This bug was there before my commit about timers and i guess buffs were not shown at all when mc.
