### PR TITLE
Casting bar compatibility

### DIFF
--- a/LunaUnitFrames.lua
+++ b/LunaUnitFrames.lua
@@ -980,23 +980,39 @@ function LunaUF:HideBlizzard()
 	-- Castbar
 	local CastingBarFrame = getglobal("CastingBarFrame")
 	if self.db.profile.blizzard.castbar then
-		CastingBarFrame:RegisterEvent("SPELLCAST_START")
-		CastingBarFrame:RegisterEvent("SPELLCAST_STOP")
-		CastingBarFrame:RegisterEvent("SPELLCAST_FAILED")
-		CastingBarFrame:RegisterEvent("SPELLCAST_INTERRUPTED")
-		CastingBarFrame:RegisterEvent("SPELLCAST_DELAYED")
-		CastingBarFrame:RegisterEvent("SPELLCAST_CHANNEL_START")
-		CastingBarFrame:RegisterEvent("SPELLCAST_CHANNEL_UPDATE")
-		CastingBarFrame:RegisterEvent("SPELLCAST_CHANNEL_STOP")
+		if CastingBarFrame.OldShow then
+			CastingBarFrame.Show = CastingBarFrame.OldShow
+		end
+		if CastingBarFrame.OldHide then
+			CastingBarFrame.Hide = CastingBarFrame.OldHide
+		end
+		if CastingBarFrame.OldIsShown then
+			CastingBarFrame.IsShown = CastingBarFrame.OldIsShown
+		end
+		if CastingBarFrame.OldIsVisible then
+			CastingBarFrame.IsVisible = CastingBarFrame.OldIsVisible
+		end
+		if CastingBarFrame.LUAFShown then
+			CastingBarFrame.LUAFShown = nil
+			CastingBarFrame:Show()
+		end
 	else
-		CastingBarFrame:UnregisterEvent("SPELLCAST_START")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_STOP")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_FAILED")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_INTERRUPTED")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_DELAYED")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_CHANNEL_START")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_CHANNEL_UPDATE")
-		CastingBarFrame:UnregisterEvent("SPELLCAST_CHANNEL_STOP")
+		CastingBarFrame.OldShow = CastingBarFrame.Show
+		CastingBarFrame.OldHide = CastingBarFrame.Hide
+		CastingBarFrame.OldIsShown = CastingBarFrame.IsShown
+		CastingBarFrame.OldIsVisible = CastingBarFrame.IsVisible
+		CastingBarFrame.Show = function(this)
+				this.LUAFShown = true
+			end
+		CastingBarFrame.Hide = function(this)
+				this.LUAFShown = nil
+			end
+		CastingBarFrame.IsShown = function(this)
+				return this.LUAFShown
+			end
+		CastingBarFrame.IsVisible = function(this)
+				return this.LUAFShown and this:GetParent():IsVisible()
+			end
 	end
 	--Buffs
 	if self.db.profile.blizzard.buffs then


### PR DESCRIPTION
Some macros and addons including supermacro use the stock blizzard casting bar properties to check if the player is casting or channeling a spell. Unregistering events prevents that.

This fix keeps the blizzard casting bar running while staying hidden.
