### PR TITLE
Fix issues with click casting

### DIFF
--- a/modules/units.lua
+++ b/modules/units.lua
@@ -244,6 +244,14 @@ local function ShowMenu()
 	end
 end
 
+local function CastSpellByName_IgnoreSelfCast(spell)
+	local sc = GetCVar("AutoSelfCast")
+	SetCVar("AutoSelfCast", "0")
+	-- make sure that this call doesn't fail, otherwise the CVar may not be restored
+	pcall(CastSpellByName, spell)
+	SetCVar("AutoSelfCast", sc)
+end
+
 local func = {}
 local function OnClick()
 	if Luna_Custom_ClickFunction and Luna_Custom_ClickFunction(arg1, this.unit) then
@@ -277,7 +285,7 @@ local function OnClick()
 			if func[action] then
 				func[action]()
 			else
-				CastSpellByName(action)
+				CastSpellByName_IgnoreSelfCast(action)
 				SpellStopTargeting()
 			end
 		else
@@ -291,7 +299,7 @@ local function OnClick()
 			if func[action] then
 				func[action]()
 			else
-				CastSpellByName(action)
+				CastSpellByName_IgnoreSelfCast(action)
 				SpellStopTargeting()
 			end
 			TargetLastTarget()

--- a/modules/units.lua
+++ b/modules/units.lua
@@ -260,7 +260,7 @@ local function OnClick()
 			else
 				this:ShowMenu()
 			end
-		elseif action == L["target"] or SpellIsTargeting() then
+		elseif action == L["target"] then
 			if (SpellIsTargeting()) then
 				SpellTargetUnit(this.unit)
 			elseif (CursorHasItem()) then
@@ -273,23 +273,29 @@ local function OnClick()
 			if not func[action] then
 				func[action] = loadstring(action or "")
 			end
+			SpellStopTargeting()
 			if func[action] then
 				func[action]()
 			else
 				CastSpellByName(action)
+				SpellStopTargeting()
 			end
 		else
 			if not func[action] then
 				func[action] = loadstring(action or "")
 			end
+			SpellStopTargeting()
 			Units.pauseUpdates = true
+
 			TargetUnit(this.unit)
 			if func[action] then
 				func[action]()
 			else
 				CastSpellByName(action)
+				SpellStopTargeting()
 			end
 			TargetLastTarget()
+
 			Units.pauseUpdates = nil
 		end
 	end


### PR DESCRIPTION
This pull request tries to fix these issues:
- If you try to use clickcasting on an invalid unit (for example, dead or out of range) you would end with a spell targeting cursor, or, if auto self-cast is enabled, the spell would be cast on yourself.
- Trying to use any clickcasting binding while having a spell targeting cursor would result in that spell being casted on the target.
