### PR TITLE
Perform click actions on MouseDown instead of MouseUp

### DIFF
--- a/modules/units.lua
+++ b/modules/units.lua
@@ -646,7 +646,7 @@ function Units:CreateUnit(a1, a2, a3, a4)
 
 	frame:SetFrameStrata("BACKGROUND")
 	frame:SetClampedToScreen(1)
-	frame:RegisterForClicks('LeftButtonUp', 'RightButtonUp', 'MiddleButtonUp', 'Button4Up', 'Button5Up')
+	frame:RegisterForClicks('LeftButtonDown', 'RightButtonDown', 'MiddleButtonDown', 'Button4Down', 'Button5Down')
 	frame:SetScript("OnClick", OnClick)
 	frame:SetBackdrop(LunaUF.constants.backdrop)
 	frame:SetBackdropColor(LunaUF.db.profile.bgcolor.r,LunaUF.db.profile.bgcolor.g,LunaUF.db.profile.bgcolor.b,LunaUF.db.profile.bgalpha)


### PR DESCRIPTION
This slightly improves reaction times when using clickcasting.
Personally I can't imagine a use case where acting on MouseUp would be preferable, but I can add an option if you think that MouseUp is a better default.