### PR TITLE
Cast Delay Bug

### DIFF
--- a/modules/cast.lua
+++ b/modules/cast.lua
@@ -568,7 +568,7 @@ local function OnEvent()
 		if arg1 then
 			frame.castBar.delaySum = (frame.castBar.delaySum or 0) + (arg1 / 1000)
 			local statusMin, statusMax = frame.castBar.bar:GetMinMaxValues()
-			frame.castBar.bar:SetMinMaxValues(statusMin, (statusMax + frame.castBar.delaySum))
+			frame.castBar.bar:SetMinMaxValues(statusMin, (statusMax + (arg1 / 1000)))
 		end
 	elseif event == "SPELLCAST_START" then
 		frame.castBar.maxValue = (arg2 / 1000)


### PR DESCRIPTION
When casting was delayed, the cast bar was getting extended for the total time delayed instead of the added delay.

EX: 
3s cast + 1s delay + 1s delay
Led to max of 3s -> 4s -> 6s