### PR TITLE
Update LunaUnitFrames.lua

### DIFF
--- a/LunaUnitFrames.lua
+++ b/LunaUnitFrames.lua
@@ -108,7 +108,7 @@ function LunaUF:Mouseover(action)
 		if func then
 			func()
 		else
-			CastSpellByName(action)
+			CastSpellByName(action,1)
 		end
 	end
 end


### PR DESCRIPTION
I didn't find the present functionality to be very useful in this regard. This small two character change makes a world of difference for me. Now I don't need an auto self cast modifier which frees up the alt modifier for abilities, macros, items, ect... If one needs to cast a heal on a random target that is not in the party or raid (a very miscule praportion of the heals one will cast) he can always click the target first then the heal instead of the heal and then the target. A very very small trade trade off for the extra utility gained.