### PR TITLE
Clear ToT and ToToT on target clearing

### DIFF
--- a/modules/units.lua
+++ b/modules/units.lua
@@ -123,6 +123,10 @@ local function UnitWatchOnEvent()
 			end
 		elseif frame:IsShown() and LunaUF.db.profile.locked then
 			frame:Hide()
+			frame = unitFrames.targettarget
+			frame:Hide()
+			frame = unitFrames.targettargettarget
+			frame:Hide()
 		end
 	elseif event == "UNIT_PET" and arg1 == "player" then
 		if unitFrames["pet"] then


### PR DESCRIPTION
At this point target of target and target of target of target frames are "left behind" a little bit after clearing the player's target, i found this annoying a bit and changed.

Before:
http://imgur.com/a/VhrPt