### PR TITLE
Fixed UnitName() on nil unit error

### DIFF
--- a/modules/incheal.lua
+++ b/modules/incheal.lua
@@ -5,7 +5,7 @@ local HealComm = LunaUF.HealComm
 
 local function OnHeal(target)
 	for _,frame in pairs(LunaUF.Units.frameList) do
-		if frame.incheal and LunaUF.db.profile.units[frame.unitGroup].incheal.enabled and UnitName(frame.unit) == target and (UnitInRaid(frame.unit) or UnitInParty(frame.unit) or UnitIsUnit("player",frame.unit)) then
+		if frame.incheal and LunaUF.db.profile.units[frame.unitGroup].incheal.enabled and frame.unit and UnitName(frame.unit) == target and (UnitInRaid(frame.unit) or UnitInParty(frame.unit) or UnitIsUnit("player",frame.unit)) then
 			Incheal:FullUpdate(frame)
 		end
 	end


### PR DESCRIPTION
`Interface\Addons\LunaUnitFrames\modules\incheal.lua:8: Usage UnitName("unit")`

It seemed as though it was checking a pet frame which had no associated unit and erroring out on that.
Seems to be fairly inconsistent though and I wasn't able to pinpoint the exact cause.