### PR TITLE
Use only the next tick of a hot rather than the full value

### DIFF
--- a/modules/incheal.lua
+++ b/modules/incheal.lua
@@ -126,8 +126,8 @@ function IncHeal:PositionBar(frame, incAmount)
 end
 
 function IncHeal:Update(frame)
-  local castedHeals = (HealComm:GetHealAmount(frame.unitGUID, HealComm.CASTED_HEALS) or 0)
-  local nextHotTick = (HealComm:GetHealAmount(frame.unitGUID, HealComm.HOT_HEALS, GetTime() + 3) or 0)
+	local castedHeals = (HealComm:GetHealAmount(frame.unitGUID, HealComm.CASTED_HEALS) or 0)
+	local nextHotTick = (HealComm:GetHealAmount(frame.unitGUID, HealComm.HOT_HEALS, GetTime() + 3) or 0)
 	local amount =  (castedHeals + nextHotTick)  * (HealComm:GetHealModifier(frame.unitGUID) or 1)
 	frame.incomingHeal = amount
 	if( not frame.visibility.incHeal or not frame.visibility.healthBar ) then return end

--- a/modules/incheal.lua
+++ b/modules/incheal.lua
@@ -37,7 +37,7 @@ function IncHeal:OnLayoutApplied(frame)
 	bar:SetOrientation(frame.healthBar:GetOrientation())
 	bar:SetReverseFill(frame.healthBar:GetReverseFill())
 	bar:Hide()
-	
+
 	local cap = LunaUF.db.profile.units[frame.unitType].incHeal.cap or 1.30
 
 	if( ( LunaUF.db.profile.units[frame.unitType].healthBar.invert and LunaUF.db.profile.units[frame.unitType].healthBar.backgroundAlpha == 0 ) or ( not LunaUF.db.profile.units[frame.unitType].healthBar.invert and LunaUF.db.profile.units[frame.unitType].healthBar.backgroundAlpha == 1 ) ) then
@@ -51,7 +51,7 @@ function IncHeal:OnLayoutApplied(frame)
 		end
 
 		bar:ClearAllPoints()
-		
+
 		local point = bar:GetReverseFill() and "RIGHT" or "LEFT"
 		bar:SetPoint("TOP" .. point, frame.healthBar)
 		bar:SetPoint("BOTTOM" .. point, frame.healthBar)
@@ -126,7 +126,9 @@ function IncHeal:PositionBar(frame, incAmount)
 end
 
 function IncHeal:Update(frame)
-	local amount = (HealComm:GetHealAmount(frame.unitGUID, HealComm.ALL_HEALS) or 0) * (HealComm:GetHealModifier(frame.unitGUID) or 1)
+  local castedHeals = (HealComm:GetHealAmount(frame.unitGUID, HealComm.CASTED_HEALS) or 0)
+  local nextHotTick = (HealComm:GetHealAmount(frame.unitGUID, HealComm.HOT_HEALS, GetTime() + 3) or 0)
+	local amount =  (castedHeals + nextHotTick)  * (HealComm:GetHealModifier(frame.unitGUID) or 1)
 	frame.incomingHeal = amount
 	if( not frame.visibility.incHeal or not frame.visibility.healthBar ) then return end
 	self:PositionBar(frame, amount)


### PR DESCRIPTION
also auto removed some whitespace

It gets very confusing to see entire hot values, as it may be a LONG time before they're actually healed for this amount.

resolves https://github.com/Aviana/LunaUnitFrames/issues/485