### PR TITLE
Add option to always show Reckoning stacks

### DIFF
--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -409,6 +409,8 @@ local L = {
 ["Color tags"] = "Color tags",
 ["Targeting sound"] = "Targeting sound",
 ["Enable the sound when switching target"] = "Enable the sound when switching target",
+["Always shown"] = "Always shown",
+["Show the bar even when inactive."] = "Show the bar even when inactive.",
 }
 
 LunaUF.L = L

--- a/modules/Options.lua
+++ b/modules/Options.lua
@@ -124,7 +124,7 @@ function LunaUF:CreateConfig()
 			db = db[info[i]]
 		end
 		db[info[#info]] = value
-		
+
 		LunaUF.Layout:Reload(info[1])
 	end
 
@@ -219,7 +219,7 @@ function LunaUF:CreateConfig()
 		for _, name in pairs(SML:List(mediaType)) do
 			MediaList[mediaType][name] = name
 		end
-		
+
 		return MediaList[mediaType]
 	end
 
@@ -247,20 +247,20 @@ function LunaUF:CreateConfig()
 		local unit = info[#info-1]
 		local db = LunaUF.db.profile.units[unit]
 		local alreadySet = {}
-		
+
 		db.attribPoint = value
 		if unit == "party" then
 			LunaUF.db.profile.units.partytarget.attribPoint = value
 			LunaUF.db.profile.units.partypet.attribPoint = value
 		end
-		
+
 		-- Simply re-set all frames is easier than making a complicated selection algorithm
 		for unitName, name in pairs(UnitToFrame) do
 			if unitName ~= "None" and name ~= "UIParent" and _G[name] then
 				LunaUF.modules.movers:SetFrame(_G[name])
 			end
 		end
-		
+
 		LunaUF.Units:ReloadHeader(unit)
 		if unit == "party" then
 			LunaUF.Units:ReloadHeader("partytarget")
@@ -428,7 +428,7 @@ function LunaUF:CreateConfig()
 			frame = _G[UnitToFrame[info[#info-1]]]
 		end
 		LunaUF.modules.movers:SetFrame(frame)
-		
+
 		-- Notify the configuration it can update itself now
 		if( ACR ) then
 			ACR:NotifyChange("LunaUnitFrames")
@@ -2985,22 +2985,28 @@ function LunaUF:CreateConfig()
 					type = "toggle",
 					order = 1,
 				},
+				showAlways = {
+					name = L["Always shown"],
+					desc = L["Show the bar even when inactive."],
+					type = "toggle",
+					order = 2,
+				},
 				description = {
 					name = L["Note: This bar only works with 5/5 Reckoning and at least 1/5 Redoubt talents."],
 					type = "description",
-					order = 2,
+					order = 3,
 				},
 				background = {
 					name = L["Background"],
 					desc = string.format(L["Enable or disable the %s."], L["Background"]),
 					type = "toggle",
-					order = 3,
+					order = 4,
 				},
 				backgroundAlpha = {
 					name = L["Background alpha"],
 					desc = L["Set the background alpha."],
 					type = "range",
-					order = 4,
+					order = 5,
 					min = 0.01,
 					max = 1,
 					step = 0.01,
@@ -3009,7 +3015,7 @@ function LunaUF:CreateConfig()
 					name = L["Height"],
 					desc = L["Set the height."],
 					type = "range",
-					order = 5,
+					order = 6,
 					min = 1,
 					max = 10,
 					step = 0.1,
@@ -3018,7 +3024,7 @@ function LunaUF:CreateConfig()
 					name = L["Order"],
 					desc = L["Set the order priority."],
 					type = "range",
-					order = 6,
+					order = 7,
 					min = 0,
 					max = 100,
 					step = 5,
@@ -3027,11 +3033,11 @@ function LunaUF:CreateConfig()
 					name = L["Growth direction"],
 					desc = L["Growth direction"],
 					type = "select",
-					order = 7,
+					order = 8,
 					values = {["LEFT"] = L["Left"], ["RIGHT"] = L["Right"]},
 				},
 				statusbar = {
-					order = 8,
+					order = 9,
 					type = "select",
 					name = L["Bar texture"],
 					dialogControl = "LSM30_Statusbar",
@@ -5762,7 +5768,7 @@ function LunaUF:CreateConfig()
 	end
 	AceConfigRegistry:RegisterOptionsTable(Addon, aceoptions, true)
 	aceoptions.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)
-	
+
 	AceConfigDialog:AddToBlizOptions(Addon, nil, nil, "general")
 	AceConfigDialog:AddToBlizOptions(Addon, L["Colors"], Addon, "colors")
 	for _,unit in ipairs(LunaUF.unitList) do
@@ -5771,6 +5777,6 @@ function LunaUF:CreateConfig()
 	AceConfigDialog:AddToBlizOptions(Addon, L["Hide Blizzard"], Addon, "hidden")
 	AceConfigDialog:AddToBlizOptions(Addon, L["Tag Help"], Addon, "help")
 	AceConfigDialog:AddToBlizOptions(Addon, L["Profiles"], Addon, "profile")
-	
+
 	AceConfigDialog:SetDefaultSize(Addon, 895, 570)
 end

--- a/modules/defaults.lua
+++ b/modules/defaults.lua
@@ -59,7 +59,7 @@ function LunaUF:LoadDefaults()
 			enabled = true,
 			healthBar = { enabled = true, background = true, backgroundAlpha = 0.2, colorType = "class", reactionType="npc", height = 6, order = 10},
 			powerBar = { enabled = true, background = true, backgroundAlpha = 0.2, height = 4.5, order = 20, colorType = "type" },
-			reckStacks = { enabled = true, growth = "RIGHT", order = 70, height = 2, background = true, backgroundAlpha = 0.2 },
+			reckStacks = { enabled = true, showAlways = false, growth = "RIGHT", order = 70, height = 2, background = true, backgroundAlpha = 0.2 },
 			portrait = {enabled = true, type = "3D", alignment = "LEFT", width = 0.22, height = 4, order = 15, fullBefore = 0, fullAfter = 100},
 			castBar = { enabled = true, background = true, backgroundAlpha = 0.2, height = 3, icon = "HIDE", autoHide = true, order = 60},
 			xpBar = { enabled = false, height = 2, order = 80, background = false, backgroundAlpha = 0.2, Alpha = 1 },


### PR DESCRIPTION
This PR adds a config option to always show the bar with Reckoning stacks.

The functionality itself is already present, but there was no option to enable it:
https://github.com/Aviana/LunaUnitFrames/blob/6ce3e70e921cce5acc65082d1fce6992fd07ed5f/modules/reckstacks.lua#L116

To preserve the current behavior, the added option is disabled by default.