### PR TITLE
Fix arithmetic on strings in Tags.lua

### DIFF
--- a/modules/Tags.lua
+++ b/modules/Tags.lua
@@ -303,11 +303,11 @@ local defaultTags = {
 									end
 								end
 								if hp > 1000 then
-									hp = (math.floor(hp/100)/10).."K"
+									hp = (math.floor(hp/100)/10)
 								end
 								local maxhp = UnitHealthMax(unit)
 								if maxhp > 1000 then
-									maxhp = (math.floor(maxhp/100)/10).."K"
+									maxhp = (math.floor(maxhp/100)/10)
 								end
 								if UnitIsGhost(unit) then
 									return L["Ghost"]
@@ -320,7 +320,7 @@ local defaultTags = {
 										return math.ceil((hp / maxhp) * 100).."%"
 									end
 								end
-								return hp.."/"..maxhp
+								return hp.."K/"..maxhp.."K"
 							end;
 	["ssmarthealthp"]			= function(frame, unit)
 								local hp = UnitHealth(unit)
@@ -332,11 +332,11 @@ local defaultTags = {
 									end
 								end
 								if hp > 1000 then
-									hp = (math.floor(hp/100)/10).."K"
+									hp = (math.floor(hp/100)/10)
 								end
 								local maxhp = UnitHealthMax(unit)
 								if maxhp > 1000 then
-									maxhp = (math.floor(maxhp/100)/10).."K"
+									maxhp = (math.floor(maxhp/100)/10)
 								end
 								if UnitIsGhost(unit) then
 									return L["Ghost"]
@@ -349,7 +349,7 @@ local defaultTags = {
 										return math.ceil((hp / maxhp) * 100).."%"
 									end
 								end
-								return hp.."/"..maxhp.." "..math.ceil((UnitHealth(unit) / UnitHealthMax(unit)) * 100).."%"
+								return hp.."K/"..maxhp.."K "..math.ceil((UnitHealth(unit) / UnitHealthMax(unit)) * 100).."%"
 							end;
 	["healhp"]				= function(frame, unit)
 								local heal = frame.incomingHeal or 0
@@ -385,14 +385,14 @@ local defaultTags = {
 									end
 								end
 								if hp > 1000 then
-									hp = (math.floor(hp/100)/10).."K"
+									hp = (math.floor(hp/100)/10)
 								end
 								if UnitIsGhost(unit) then
 									return L["Ghost"]
 								elseif not UnitIsConnected(unit) then
 									return L["Offline"]
 								end
-								return hp
+								return hp.."K"
 							end;
 	["maxhp"]				= function(frame, unit)
 								return UnitHealthMax(unit)


### PR DESCRIPTION
You ended up trying to perform compare and arithmetic on a few string/number combinations by concatenating "K" after HP/MaxHP values before final calculations. This change moves them to `return` arguments.