### PR TITLE
Update the order of checks in health functions

### DIFF
--- a/modules/Tags.lua
+++ b/modules/Tags.lua
@@ -322,6 +322,7 @@ local defaultTags = {
 							end;
 	["ssmarthealthp"]			= function(frame, unit)
 								local hp = UnitHealth(unit)
+								local maxhp = UnitHealthMax(unit)
 								if hp < 1 then
 									if feigncheck(unit) then
 										return L["Feigned"]
@@ -343,7 +344,6 @@ local defaultTags = {
 								if hp > 1000 then
 									hp = (math.floor(hp/100)/10).."K"
 								end
-								local maxhp = UnitHealthMax(unit)
 								if maxhp > 1000 then
 									maxhp = (math.floor(maxhp/100)/10).."K"
 								end

--- a/modules/Tags.lua
+++ b/modules/Tags.lua
@@ -270,10 +270,8 @@ local defaultTags = {
 								return hp.."/"..maxhp
 							end;
 	["smarthealthp"]			= function(frame, unit)
-								local hp
-								local maxhp
-								hp = UnitHealth(unit)
-								maxhp = UnitHealthMax(unit)
+								local hp = UnitHealth(unit)
+								local maxhp = UnitHealthMax(unit)
 								if UnitIsGhost(unit) then
 									return L["Ghost"]
 								elseif not UnitIsConnected(unit) then
@@ -295,19 +293,13 @@ local defaultTags = {
 							end;
 	["ssmarthealth"]			= function(frame, unit)
 								local hp = UnitHealth(unit)
+								local maxhp = UnitHealthMax(unit)
 								if hp < 1 then
 									if feigncheck(unit) then
 										return L["Feigned"]
 									else
 										return L["Dead"]
 									end
-								end
-								if hp > 1000 then
-									hp = (math.floor(hp/100)/10).."K"
-								end
-								local maxhp = UnitHealthMax(unit)
-								if maxhp > 1000 then
-									maxhp = (math.floor(maxhp/100)/10).."K"
 								end
 								if UnitIsGhost(unit) then
 									return L["Ghost"]
@@ -319,6 +311,12 @@ local defaultTags = {
 									else
 										return math.ceil((hp / maxhp) * 100).."%"
 									end
+								end
+								if hp > 1000 then
+									hp = (math.floor(hp/100)/10).."K"
+								end
+								if maxhp > 1000 then
+									maxhp = (math.floor(maxhp/100)/10).."K"
 								end
 								return hp.."/"..maxhp
 							end;
@@ -331,13 +329,6 @@ local defaultTags = {
 										return L["Dead"]
 									end
 								end
-								if hp > 1000 then
-									hp = (math.floor(hp/100)/10).."K"
-								end
-								local maxhp = UnitHealthMax(unit)
-								if maxhp > 1000 then
-									maxhp = (math.floor(maxhp/100)/10).."K"
-								end
 								if UnitIsGhost(unit) then
 									return L["Ghost"]
 								elseif not UnitIsConnected(unit) then
@@ -348,6 +339,13 @@ local defaultTags = {
 									else
 										return math.ceil((hp / maxhp) * 100).."%"
 									end
+								end
+								if hp > 1000 then
+									hp = (math.floor(hp/100)/10).."K"
+								end
+								local maxhp = UnitHealthMax(unit)
+								if maxhp > 1000 then
+									maxhp = (math.floor(maxhp/100)/10).."K"
 								end
 								return hp.."/"..maxhp.." "..math.ceil((UnitHealth(unit) / UnitHealthMax(unit)) * 100).."%"
 							end;


### PR DESCRIPTION
I was getting 'arithmetic on string' errors because of the order of the checks were being performed.