### PR TITLE
Update auras.lua

### DIFF
--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -225,7 +225,7 @@ end
 
 function Auras:UpdateFrames(frame)
 	local config = LunaUF.db.profile.units[frame.unitType].auras
-	local name, texture, count, auraType, duration, endTime, caster, spellID, main, off
+	local name, texture, count, auraType, duration, endTime, caster, spellID, main, off, _
 	local filter = "HELPFUL"..(config.filterbuffs == 2 and "|PLAYER" or config.filterbuffs == 3 and "|RAID" or "")
 	for i,button in ipairs(frame.auras.buffbuttons.buttons) do
 		button.cooldown.noCooldownCount = LunaUF.db.profile.omnicc


### PR DESCRIPTION
"Global variable _ tainted by LunaUnitFrames - Interface\AddOns\LunaUnitFrames\modules\auras.lua:337 UpdateFrames()"
At first I thought its just a forgotten local before variable declaration .. but you did the better and declared the vars at the start ... just not added the _ or at least that fixed the issue ( tbh from lua implementation in wow i have not run into this kind of issue on older versions _ is thrown away and never caused taints )